### PR TITLE
Improve grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # BOAST
 
-The BOAST (BOLD Optimisation for Acquisition Sensitivity Tool) toolbox for SPM helps optimizing echo planar imaging (EPI) protocols for maximal BOLD sensitivity, particularly, where affected by susceptibility artifacts.
+The BOAST (BOLD Optimisation for Acquisition Sensitivity Tool) toolbox for SPM helps to optimize echo-planar imaging (EPI) protocols for maximal BOLD sensitivity, particularly, where affected by susceptibility artifacts.
 
-Optimal use of and settings of z-shim, gradient polarity and slice tilt can significantly increase the BOLD sensitivity. Since the method is based on numerical simulations it does not require expensive measurements like previous approaches. This also improves its flexibility and automation.
+Optimal use of and settings of z-shim, gradient polarity, and slice tilt can significantly increase the BOLD sensitivity. Since the method is based on numerical simulations it does not require expensive measurements like previous approaches. This also improves its flexibility and automation.
 
 The approach and its applications are described in detail in the open access publication by Volz et al. ([Neuroimage 2019](https://doi.org/10.1016/j.neuroimage.2018.12.052)).
 
-
-Developers
+## Developers
 
 The software is developed in a collaboration between the Max Planck Institute for Human Cognitive ad Brain Sciences, Leipzig, and the Wellcome Centre for Human Neuroimaging, UCL, London.


### PR DESCRIPTION
The verb "help" should be followed by the to-infinite form. Oxford comma.